### PR TITLE
Adapt tests to RPM 6

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -130,7 +130,7 @@ ok(RPM2->expand_macro("%rpm2_test_macro") eq "testval $$");
 RPM2->delete_macro("rpm2_test_macro");
 ok(RPM2->expand_macro("%rpm2_test_macro") eq "%rpm2_test_macro");
 
-ok(RPM2->rpm_api_version =~ /4.\d+/);
+ok(RPM2->rpm_api_version =~ /^(?:\d+(?:\.\d+)?)$/);
 
 #
 # Clean up before transaction tests (close the database

--- a/test.pl
+++ b/test.pl
@@ -156,7 +156,7 @@ ok($t->order());
 my @rpms = $t->elements();
 ok($rpms[0] eq  $pkg->as_nvre());
 ok(scalar(@rpms) == 1);
-skip( ( $< == 0 ) ? undef : ': must be root to create RPM transaction.',  ( $< == 0 ) ? $t->run() : undef );
+skip( ( $< == 0 ) ? undef : ': must be root to create RPM transaction.',  ( $< == 0 ) ? $t->run('', 1<<9) : undef );
 $t = undef;
 # See if we can find the rpm in the database now...
 $db = RPM2->open_rpm_db();


### PR DESCRIPTION
A test failed after upgrading RPM to 5.99.90, an RPM 6 prerelease:

    # Failed test 38 in test.pl at line 133
    #  test.pl line 133 is: ok(RPM2->rpm_api_version =~ /4.\d+/);

The rpm_api_version() call returns "5.99" now.

This patch fixes the check to accept 6.yy and 5.99 values.