### PR TITLE
tests: Use File::Temp for creating temporary directories

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -24,6 +24,9 @@ my $build = new Module::Build (
 		'File::Basename' => 0,
 		'File::Spec' => 0,
 	},
+    test_requires => {
+        'File::Temp' => 0.19,
+    },
 	extra_compiler_flags => $api_version.scalar `pkg-config rpm --cflags`,
 	extra_linker_flags => scalar `pkg-config rpm --libs`,
 	build_requires => {

--- a/test.pl
+++ b/test.pl
@@ -14,6 +14,7 @@ use strict;
 BEGIN { plan tests => 62 };
 use RPM2;
 use POSIX;
+use File::Temp 0.19;
 ok(1); # If we made it this far, we're ok.
 
 #########################
@@ -116,10 +117,10 @@ ok(($pkg <=> $pkg2) == 0);
 ok(!($pkg < $pkg2));
 ok(!($pkg > $pkg2));
 
-my $other_rpm_dir = getcwd() . '/rpmdb';
+my $other_rpm_dir = File::Temp->newdir();
 # another rpm, handily provided by the rpmdb-redhat package
 # ... is no longer shipped. Create a new one:
-system( "rm -rf rpmdb; mkdir rpmdb; /usr/bin/rpmdb --dbpath $other_rpm_dir --initdb" );
+system( "/usr/bin/rpmdb --dbpath $other_rpm_dir --initdb" );
 my $db2 = RPM2->open_rpm_db(-path => $other_rpm_dir);
 ok(defined $db2);
 $db2 = undef;


### PR DESCRIPTION
Current tests write into a fixed-name path in a working directory. That prevents from running the tests from a read-only location.